### PR TITLE
Add python3.8 support by unpinning versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
+- '3.8'
 
 # command to install dependencies
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pandas==0.24.2
-h5py==2.9.0
-Keras==2.2.4
-numpy==1.16.4
-tensorflow==1.15.2
+pandas>=0.24.2
+h5py>=2.9.0
+Keras>=2.2.4
+numpy>=1.16.4
+tensorflow>=1.15.2

--- a/setup.py
+++ b/setup.py
@@ -115,11 +115,11 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'pandas==0.24.2',
-        'h5py==2.9.0',
-        'Keras==2.2.4',
-        'numpy==1.16.4',
-        'tensorflow==1.15.2'
+        'pandas>=0.24.2',
+        'h5py>=2.9.0',
+        'Keras>=2.2.4',
+        'numpy>=1.16.4',
+        'tensorflow>=1.15.2'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
On python3.8, installation fails due to incompatible version requirements on the h5py dependency (and possibly others). This changes the version requirements to be a minimum viable version, which fixes the python 3.8 installation problems.

In addition, it adds python 3.8 to the TravisCI config.