### PR TITLE
Revert Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
 - '3.5'
 - '3.6'
 - '3.7'
-- '3.8'
 
 # command to install dependencies
 install:

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,9 @@ Or ::
    
    conda install -c soodoku ethnicolr 
 
-Note: If you are installing on Windows, Theano installation typically needs admin. privileges on the shell.
+Notes: 
+ - Tensorflow 2.X is not supported at this time, therefore only Python 3.7 and lower will work.
+ - If you are installing on Windows, Theano installation typically needs admin. privileges on the shell.
 
 General API
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pandas>=0.24.2
-h5py>=2.9.0
-Keras>=2.2.4
-numpy>=1.16.4
-tensorflow>=1.15.2
+pandas==0.24.2
+h5py==2.9.0
+Keras==2.2.4
+numpy==1.16.4
+tensorflow==1.15.2

--- a/setup.py
+++ b/setup.py
@@ -116,11 +116,11 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'pandas>=0.24.2',
-        'h5py>=2.9.0',
-        'Keras>=2.2.4',
-        'numpy>=1.16.4',
-        'tensorflow>=1.15.2'
+        'pandas==0.24.2',
+        'h5py==2.9.0',
+        'Keras==2.2.4',
+        'numpy==1.16.4',
+        'tensorflow==1.15.2'
     ],
 
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
Python 3.8 only supports Tensorflow 2.X. Right now, Ethnicolr has an error (#29) with 2.X, and therefore Python 3.8 doesn't work with Ethnicolr as well.

Python 3.8 support was added in commit 79901af, but it still passed through tests (despite #29), which is why it should be reverted.