### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/ethnicolr/utils.py
+++ b/ethnicolr/utils.py
@@ -145,7 +145,7 @@ def transform_and_pred(
         pdf = pd.DataFrame()
 
         for _ in range(num_iter):
-            pdf = pdf.append(pd.DataFrame(cls.model(X, training=True)))
+            pdf = pd.concat([pdf, pd.DataFrame(cls.model(X, training=True))])
         print(cls.race)
         pdf.columns = cls.race
         pdf["rowindex"] = pdf.index

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-tensorflow==2.5.3
+tensorflow>=2.5.3
 pandas>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Utilities",
@@ -108,7 +110,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=["tensorflow==2.5.3", "pandas>=1.3.0"],
+    install_requires=["tensorflow>=2.5.3", "pandas>=1.3.0"],
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
     # for example:


### PR DESCRIPTION
- Mark Python 3.9 and 3.10 as compatible
- Add 3.10 to the test matrix
- Unlock tensorflow and pandas

Ref: #61
