### PR TITLE
Normalize names before wiki predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ optional arguments:
   -l LAST, --last LAST  Name of the column containing the last name
 ```
 
+### Cleaning Names
+
+The prediction models work best when first and last names contain only
+alphabetic characters. Before calling the CLI or Python APIs, strip out
+titles (e.g., *Dr*, *Hon.*), middle names, suffixes, punctuation and
+non\-ASCII characters. The `pred_wiki_name` command automatically
+normalizes names by removing diacritics and extraneous characters. If
+the tool still skips entries, check that the first and last name columns
+are not empty after cleaning.
+
 ## Examples
 
 To append census data from 2010 to a [file with column header in the

--- a/ethnicolr/pred_wiki_name.py
+++ b/ethnicolr/pred_wiki_name.py
@@ -9,6 +9,8 @@ Predicts race/ethnicity using full names based on LSTM models trained on Wikiped
 import sys
 import os
 import logging
+import re
+import unicodedata
 from typing import List, Optional
 import pandas as pd
 from pkg_resources import resource_filename
@@ -21,6 +23,24 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize a name by removing accents and punctuation.
+
+    The Wikipedia models expect names containing only ASCII letters.
+    This helper strips diacritics, drops any non-letter characters and
+    collapses multiple spaces. The cleaned string is title cased to match
+    the model's training format.
+    """
+    # Remove accents
+    name = unicodedata.normalize("NFKD", str(name))
+    name = name.encode("ascii", "ignore").decode("utf-8")
+    # Drop everything except letters and spaces
+    name = re.sub(r"[^A-Za-z ]+", " ", name)
+    # Condense whitespace and strip
+    name = re.sub(r"\s+", " ", name).strip()
+    return name.title()
 
 
 class WikiNameModel(EthnicolrModelClass):
@@ -88,7 +108,7 @@ class WikiNameModel(EthnicolrModelClass):
         working_df[temp_col] = (
             working_df[lname_col].fillna("").astype(str).str.strip() + " " +
             working_df[fname_col].fillna("").astype(str).str.strip()
-        ).str.title()
+        ).apply(_normalize_name)
 
         # Remove rows with empty names
         before = len(working_df)


### PR DESCRIPTION
## Summary
- normalize first/last names in `pred_wiki_name` to strip diacritics and punctuation
- document name cleaning requirements in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tensorflow')*
- `python -m pip install tensorflow==2.13.0` *(fails: No matching distribution found for tensorflow==2.13.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b1691d447c832f8f03e511765028bf