### PR TITLE
Normalize names before wiki predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ optional arguments:
   -l LAST, --last LAST  Name of the column containing the last name
 ```
 
+### Cleaning Names
+
+The prediction models work best when first and last names contain only
+alphabetic characters. Before calling the CLI or Python APIs, strip out
+titles (e.g., *Dr*, *Hon.*), middle names, suffixes, punctuation and
+non\-ASCII characters. The `pred_wiki_name` command automatically
+normalizes names by removing diacritics and extraneous characters. If
+the tool still skips entries, check that the first and last name columns
+are not empty after cleaning. An `ethnicolr_name` column is added to the
+output to show the normalized form used for prediction so you can map
+results back to your original data.
+
 ## Examples
 
 To append census data from 2010 to a [file with column header in the

--- a/ethnicolr/pred_wiki_name.py
+++ b/ethnicolr/pred_wiki_name.py
@@ -9,6 +9,8 @@ Predicts race/ethnicity using full names based on LSTM models trained on Wikiped
 import sys
 import os
 import logging
+import re
+import unicodedata
 from typing import List, Optional
 import pandas as pd
 from pkg_resources import resource_filename
@@ -21,6 +23,24 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize a name by removing accents and punctuation.
+
+    The Wikipedia models expect names containing only ASCII letters.
+    This helper strips diacritics, drops any non-letter characters and
+    collapses multiple spaces. The cleaned string is title cased to match
+    the model's training format.
+    """
+    # Remove accents
+    name = unicodedata.normalize("NFKD", str(name))
+    name = name.encode("ascii", "ignore").decode("utf-8")
+    # Drop everything except letters and spaces
+    name = re.sub(r"[^A-Za-z ]+", " ", name)
+    # Condense whitespace and strip
+    name = re.sub(r"\s+", " ", name).strip()
+    return name.title()
 
 
 class WikiNameModel(EthnicolrModelClass):
@@ -77,22 +97,30 @@ class WikiNameModel(EthnicolrModelClass):
 
         working_df = df.copy()
 
-        # Create a safe temporary name column
+        # Create safe temporary columns
+        raw_col = "__ethnicolr_raw_name"
+        norm_col = "__ethnicolr_clean_name"
         temp_col = "__ethnicolr_temp_name"
+
+        while raw_col in working_df.columns:
+            raw_col += "_"
+        while norm_col in working_df.columns:
+            norm_col += "_"
         while temp_col in working_df.columns:
             temp_col += "_"
 
         logger.info(f"Processing {len(working_df)} names")
 
-        # Create full name with NA handling
-        working_df[temp_col] = (
+        # Create full name and normalized variant
+        working_df[raw_col] = (
             working_df[lname_col].fillna("").astype(str).str.strip() + " " +
             working_df[fname_col].fillna("").astype(str).str.strip()
-        ).str.title()
+        )
+        working_df[norm_col] = working_df[raw_col].apply(_normalize_name)
 
-        # Remove rows with empty names
+        # Remove rows with empty normalized names
         before = len(working_df)
-        working_df = working_df[working_df[temp_col].str.strip().str.len() > 0]
+        working_df = working_df[working_df[norm_col].str.strip().str.len() > 0]
         after = len(working_df)
 
         if before > after:
@@ -104,8 +132,11 @@ class WikiNameModel(EthnicolrModelClass):
         try:
             logger.info(f"Applying Wikipedia name model (confidence interval: {conf_int})")
 
-            rdf = cls.transform_and_pred(
-                df=working_df,
+            # Deduplicate normalized names for efficient prediction
+            unique_df = working_df[[norm_col]].drop_duplicates().rename(columns={norm_col: temp_col})
+
+            preds = cls.transform_and_pred(
+                df=unique_df,
                 newnamecol=temp_col,
                 vocab_fn=vocab_path,
                 race_fn=race_path,
@@ -116,9 +147,12 @@ class WikiNameModel(EthnicolrModelClass):
                 conf_int=conf_int
             )
 
-            # Clean up temporary column
-            if temp_col in rdf.columns:
-                rdf.drop(columns=[temp_col], inplace=True)
+            # Merge predictions back to the full DataFrame
+            rdf = working_df.merge(preds, left_on=norm_col, right_on=temp_col, how="left")
+
+            # Clean up temporary columns
+            rdf.drop(columns=[temp_col, raw_col], inplace=True, errors="ignore")
+            rdf.rename(columns={norm_col: "ethnicolr_name"}, inplace=True)
 
             predicted = rdf.dropna(subset=["race"]).shape[0]
             logger.info(f"Predicted {predicted} of {after} names ({predicted / after * 100:.1f}%)")


### PR DESCRIPTION
## Summary
- preserve all input rows by deduplicating only normalized names and merging predictions back
- expose `ethnicolr_name` column so users can map outputs to normalized inputs
- document the new `ethnicolr_name` column in README

## Testing
- `python -m pip install tensorflow==2.17.1`
- `pytest` *(fails: ValueError: Unrecognized keyword arguments passed to Dense)*

------
https://chatgpt.com/codex/tasks/task_e_68b1691d447c832f8f03e511765028bf