### PR TITLE
Preserve row order and test initials

### DIFF
--- a/ethnicolr/ethnicolr_class.py
+++ b/ethnicolr/ethnicolr_class.py
@@ -39,8 +39,12 @@ class EthnicolrModelClass:
     @staticmethod
     def test_and_norm_df(df: pd.DataFrame, col: str) -> pd.DataFrame:
         """
-        Validates the presence of the column and removes rows with NaNs or duplicates.
-        Now with better logging about what gets removed.
+        Validate presence of ``col`` and drop rows with NaNs while preserving duplicates.
+
+        Earlier implementations removed duplicate values which could silently drop
+        rows. This caused a mismatch between the number of input rows and the
+        predictions returned. The function now keeps duplicates but logs how many
+        were found so callers remain informed.
         """
         if col not in df.columns:
             raise ValueError(f"The column '{col}' does not exist in the DataFrame.")
@@ -57,18 +61,16 @@ class EthnicolrModelClass:
         if df.empty:
             raise ValueError("The name column has no non-NaN values.")
 
-        # Track duplicate removals
-        before_dedup = len(df)
-        df = df.drop_duplicates(subset=[col])
-        after_dedup = len(df)
-
-        if before_dedup > after_dedup:
+        # Log duplicates but keep them so prediction results align with inputs
+        dup_count = df.duplicated(subset=[col]).sum()
+        if dup_count > 0:
             logger.info(
-                f"Removed {before_dedup - after_dedup} duplicate rows based on column '{col}'"
+                f"Preserving {dup_count} duplicate rows based on column '{col}'"
             )
 
+        final_length = len(df)
         logger.info(
-            f"Data filtering summary: {original_length} → {after_dedup} rows (kept {after_dedup/original_length*100:.1f}%)"
+            f"Data filtering summary: {original_length} → {final_length} rows (kept {final_length/original_length*100:.1f}%)"
         )
 
         return df
@@ -121,7 +123,9 @@ class EthnicolrModelClass:
         df = df.copy()
         df = cls.test_and_norm_df(df, newnamecol)
         df[newnamecol] = df[newnamecol].astype(str).str.strip().str.title()
-        df["__rowindex"] = np.arange(len(df))
+        rowindex_added = "__rowindex" not in df.columns
+        if rowindex_added:
+            df["__rowindex"] = np.arange(len(df))
 
         # Load model, vocab, and race label set once
         if cls.model is None:
@@ -213,5 +217,6 @@ class EthnicolrModelClass:
             final_df = df.merge(summary, on="__rowindex", how="left")
 
         # Clean up
-        final_df.drop(columns=["__rowindex"], inplace=True, errors="ignore")
+        if rowindex_added:
+            final_df.drop(columns=["__rowindex"], inplace=True, errors="ignore")
         return final_df.reset_index(drop=True)

--- a/ethnicolr/pred_wiki_name.py
+++ b/ethnicolr/pred_wiki_name.py
@@ -13,6 +13,8 @@ import sys
 import unicodedata
 from typing import List, Optional
 
+import numpy as np
+
 import pandas as pd
 from pkg_resources import resource_filename
 
@@ -102,6 +104,7 @@ class WikiNameModel(EthnicolrModelClass):
         model_path, vocab_path, race_path = cls.get_model_paths()
 
         working_df = df.copy()
+        working_df["__rowindex"] = np.arange(len(working_df))
         original_length = len(working_df)
 
         # Create a safe temporary name column

--- a/ethnicolr/tests/test_030_pred_wiki.py
+++ b/ethnicolr/tests/test_030_pred_wiki.py
@@ -107,5 +107,34 @@ class TestPredWiki(unittest.TestCase):
         )
         self.assertTrue(all(odf.true_race == odf.race))
 
+    def test_pred_wiki_name_preserves_duplicates(self):
+        dupe_df = pd.DataFrame(
+            [
+                {"last": "O'Neil", "first": "John"},
+                {"last": "ONeil", "first": "John"},
+            ]
+        )
+        out = pred_wiki_name(dupe_df, "last", "first")
+        self.assertEqual(len(out), len(dupe_df))
+        self.assertListEqual(out["last"].tolist(), dupe_df["last"].tolist())
+        self.assertListEqual(out["first"].tolist(), dupe_df["first"].tolist())
+        self.assertTrue(out["processing_status"].eq("processed").all())
+        self.assertEqual(out["race"].nunique(), 1)
+
+    def test_pred_wiki_name_handles_accents_and_initials(self):
+        tricky_df = pd.DataFrame(
+            [
+                {"last": "Szathmáry", "first": "Emöke"},
+                {"last": "McMillan", "first": "A."},
+                {"last": "FitzGerald", "first": "John"},
+                {"last": "Edwards", "first": "N"},
+                {"last": "Sauder", "first": "E"},
+                {"last": "Aguilar", "first": "J."},
+            ]
+        )
+        out = pred_wiki_name(tricky_df, "last", "first")
+        self.assertEqual(len(out), len(tricky_df))
+        self.assertTrue(out["processing_status"].eq("processed").all())
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- keep existing `__rowindex` values in `transform_and_pred` so results can be sorted back to input order
- attach row indices in `pred_wiki_name` and expand regression tests to include single-letter initials

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58c767afc832f8e1a9aa829c10a6b