### PR TITLE
Remove dropped inference extra from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --group docs --extra inference
+          uv sync --group docs
           uv add --group docs matplotlib ipython
 
       - name: Build documentation


### PR DESCRIPTION
The `inference` (TensorFlow) extra was removed in #123, but the docs workflow still passed `--extra inference` to `uv sync`, failing the build job on master. This removes the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)